### PR TITLE
Fix cases when device_entry.model is not a string

### DIFF
--- a/custom_components/powercalc/model_discovery.py
+++ b/custom_components/powercalc/model_discovery.py
@@ -73,8 +73,7 @@ async def autodiscover_model(
     device_registry = await dr.async_get_registry(hass)
     device_entry = device_registry.async_get(entity_entry.device_id)
     model_id = device_entry.model
-    match = re.search("\((.*)\)$", device_entry.model)
-    if match:
+    if match:= re.search("\((.*)\)$", str(device_entry.model)):
         model_id = match.group(1)
 
     manufacturer = device_entry.manufacturer


### PR DESCRIPTION
Integrations can report the model as something else than a string. For instance, Netatmo reports the camera flush light's model as a list `['Netatmo', 'Smart Outdoor Camera']`. This would cause the regex to crash and the component to fail to load.